### PR TITLE
Fix steps defined by step() are reversed

### DIFF
--- a/lib/transflow/flow_dsl.rb
+++ b/lib/transflow/flow_dsl.rb
@@ -27,7 +27,7 @@ module Transflow
 
     # @api public
     def steps(*names)
-      names.reverse_each { |name| step(name) }
+      names.each { |name| step(name) }
     end
 
     # @api public

--- a/lib/transflow/transaction.rb
+++ b/lib/transflow/transaction.rb
@@ -41,8 +41,8 @@ module Transflow
 
     # @api private
     def initialize(steps)
-      @steps = steps
-      @step_names = steps.keys.reverse
+      @steps = Hash[steps.to_a.reverse]
+      @step_names = steps.keys
     end
 
     # Subscribe event listeners to specific steps


### PR DESCRIPTION
Fixes issue #2 

```
Transflow(container: operations) { 
   steps(:aggregate, :persist)
 }
# order is :aggregate, :persist

Transflow(container: operations) {
    step(:aggregate, publish: true)
    step(:persist, publish: true)
}
# order is :persist, :aggregate
```