### PR TITLE
Fix error in creating steps

### DIFF
--- a/lib/transflow/transaction.rb
+++ b/lib/transflow/transaction.rb
@@ -16,9 +16,7 @@ module Transflow
     # Step wrapper object which adds `>>` operator
     #
     # @api private
-    class Step
-      include Dry::Pipeline::Mixin
-
+    class Step < Dry::Pipeline
       # @api private
       def self.[](op)
         if op.respond_to?(:>>)


### PR DESCRIPTION
I've been working on extracting dry-view from rodakase, but the rodakase specs were failing on transactions. Turns out this was the culprit. Would you mind incorporating this into a new release? That way I can make the dry-view extraction without having to change too much in rodakase at once.

Thanks!
